### PR TITLE
feat(stellar-toolkit): add wallet command for end-user onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,14 +130,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
+name = "arrayvec"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -149,24 +151,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-swap"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "hmac",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -182,71 +173,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "backtrace"
@@ -258,7 +188,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -298,6 +228,26 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -386,7 +336,7 @@ dependencies = [
  "hmac",
  "parking_lot",
  "priority-queue",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2",
  "thiserror",
@@ -401,7 +351,7 @@ dependencies = [
  "anyhow",
  "channel-router",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "serde",
  "thiserror",
  "tokio",
@@ -416,10 +366,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -468,15 +416,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "const-oid"
@@ -531,13 +470,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -624,6 +583,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -723,7 +688,7 @@ checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2",
  "zeroize",
@@ -748,7 +713,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -803,7 +768,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -818,6 +783,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
+]
 
 [[package]]
 name = "float-cmp"
@@ -955,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -970,7 +946,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.11.1",
  "slab",
  "tokio",
@@ -979,22 +955,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.0",
- "indexmap 2.11.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "byteorder",
 ]
 
 [[package]]
@@ -1010,6 +976,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+ "zeroize",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -1058,46 +1044,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.4.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1123,9 +1076,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1138,53 +1091,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1462,12 +1378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,31 +1417,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mockito"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
-dependencies = [
- "assert-json-diff",
- "bytes",
- "colored",
- "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "log",
- "pin-project-lite",
- "rand 0.9.2",
- "regex",
- "serde_json",
- "serde_urlencoded",
- "similar",
- "tokio",
 ]
 
 [[package]]
@@ -1703,7 +1598,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hmac",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2",
  "thiserror",
@@ -1733,12 +1628,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -1867,18 +1756,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1888,17 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1908,15 +1777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1968,10 +1828,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1985,7 +1845,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2005,6 +1865,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.11",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2036,12 +1910,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2146,16 +2055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,14 +2149,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
-name = "similar"
-version = "2.7.0"
+name = "simd-adler32"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2310,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
 dependencies = [
  "arbitrary",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "ethnum",
  "num-derive",
  "num-traits",
@@ -2347,15 +2246,15 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -2397,14 +2296,14 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "soroban-env-guest",
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey",
+ "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -2413,7 +2312,7 @@ version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db20def4ead836663633f58d817d0ed8e1af052c9650a04adf730525af85b964"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "darling",
  "itertools",
  "proc-macro2",
@@ -2497,44 +2396,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stellar-did"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "axum",
- "base64 0.21.7",
- "chrono",
- "ed25519-dalek",
- "hex",
- "hmac",
- "mockito",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "soroban-sdk",
- "stellar-xdr",
- "thiserror",
- "tokio",
- "tokio-test",
- "tower 0.4.13",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "stellar-strkey"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
 dependencies = [
  "base32",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "thiserror",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34ff61c0ca6f1c2b4169e8d1633417bd9225f58b6175e4e317204565d16277"
+dependencies = [
+ "crate-git-revision 0.0.9",
+ "data-encoding",
+ "heapless",
+ "zeroize",
 ]
 
 [[package]]
@@ -2543,15 +2424,23 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bip39",
  "clap",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
  "predicates",
+ "rand",
  "serde",
  "serde_json",
+ "sha2",
+ "stellar-strkey 0.0.18",
  "tempfile",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]
@@ -2562,12 +2451,12 @@ checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "escape-bytes",
  "hex",
  "serde",
  "serde_with",
- "stellar-strkey",
+ "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -2598,12 +2487,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -2727,6 +2610,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,56 +2698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,7 +2709,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2936,6 +2783,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +2845,6 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
 
@@ -3141,6 +3018,24 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3442,6 +3337,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3475,3 +3384,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "crates/watchtower",
     "crates/channel-simulator",
     "crates/atomic-swap",
-    "crates/stellar-did",
     "contracts/payment-channel-contract",
     "contracts/amm-pool",
     "contracts/amm-factory",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ stellar-toolkit deploy ./contracts/my_contract --network testnet
 
 # Verify deployment
 stellar-toolkit verify <contract_id>
+
+# Wallet commands (end-user onboarding)
+stellar-toolkit wallet generate                # new recovery phrase + keypair
+stellar-toolkit wallet recover "<phrase>"     # restore a keypair from a phrase
+stellar-toolkit wallet fund <G...>            # fund an account on testnet (Friendbot)
+stellar-toolkit wallet sign <S...> <tx_hex>   # sign a message/transaction envelope
 ```
 
 ## Project Structure
@@ -85,6 +91,25 @@ cargo test
 ```bash
 cargo run --example basic_deployment
 ```
+
+## Wallet (End-User Onboarding)
+
+The `wallet` command gives end users a self-contained way to interact with
+toolkit contracts:
+
+- **Recovery phrase backup** – `wallet generate` mints a cryptographically random
+  24-word BIP-39 recovery phrase and shows the derived Stellar secret key (`S…`)
+  and account id (`G…`). Keep the phrase somewhere safe; it is shown only once.
+- **Recovery** – `wallet recover "<phrase>"` re-derives the same keypair from an
+  existing phrase. The phrase checksum is validated first, so a mistyped phrase
+  is rejected before any key is derived.
+- **Key derivation** – keys are derived with BIP-39 plus SLIP-0010 hardened
+  Ed25519 derivation at `m/44'/148'/0'`, the standard Stellar path.
+- **Gas funding** – `wallet fund <G…>` tops up a testnet account through the
+  Friendbot faucet.
+- **Transaction building/signing** – `wallet sign <S…> <hex>` signs a message or
+  Soroban transaction envelope with the account's Ed25519 key and prints the
+  signature.
 
 ## Roadmap
 

--- a/crates/stellar-toolkit/Cargo.toml
+++ b/crates/stellar-toolkit/Cargo.toml
@@ -21,6 +21,16 @@ serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Wallet: recovery phrases, keypair derivation, signing, and funding
+bip39 = "2"
+stellar-strkey = "0.0.18"
+ureq = "2"
+ed25519-dalek.workspace = true
+sha2.workspace = true
+hmac.workspace = true
+hex.workspace = true
+rand.workspace = true
+
 [dev-dependencies]
 tempfile = "3.8"
 assert_cmd = "2.0"

--- a/crates/stellar-toolkit/src/cli.rs
+++ b/crates/stellar-toolkit/src/cli.rs
@@ -21,6 +21,32 @@ pub enum ToolkitCommand {
         #[arg(long, default_value = ".")]
         workspace: PathBuf,
     },
+    /// Wallet commands: recovery phrases, keypair derivation, funding, signing
+    #[command(subcommand)]
+    Wallet(WalletCommand),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WalletCommand {
+    /// Generate a 24-word recovery phrase and derive a Stellar keypair
+    Generate,
+    /// Recover a Stellar keypair from an existing recovery phrase
+    Recover {
+        /// The BIP-39 recovery phrase (quote it for shell safety)
+        phrase: String,
+    },
+    /// Fund a Stellar account on testnet using the Friendbot faucet
+    Fund {
+        /// The account id (G...) to fund
+        account: String,
+    },
+    /// Sign a message/transaction envelope (hex) with a secret key (S...)
+    Sign {
+        /// Stellar secret key (S...)
+        secret: String,
+        /// Message / transaction envelope as hex
+        message: String,
+    },
 }
 
 impl ToolkitCommand {
@@ -49,8 +75,42 @@ impl ToolkitCommand {
                 println!("amm_router:  {}", router.display());
                 Ok(())
             }
+            Self::Wallet(wallet) => run_wallet(wallet),
         }
     }
+}
+
+fn run_wallet(wallet: &WalletCommand) -> Result<()> {
+    use crate::wallet;
+    match wallet {
+        WalletCommand::Generate => {
+            let w = wallet::generate_wallet()?;
+            print_wallet(&w);
+            println!(
+                "\n⚠  Write down your recovery phrase and store it somewhere safe. "
+            );
+            println!("Anyone with it controls the account. It is shown only once.");
+            Ok(())
+        }
+        WalletCommand::Recover { phrase } => {
+            let w = wallet::recover_wallet(phrase)?;
+            print_wallet(&w);
+            Ok(())
+        }
+        WalletCommand::Fund { account } => wallet::fund_account(account),
+        WalletCommand::Sign { secret, message } => {
+            let signature = wallet::sign_message(secret, message)?;
+            println!("{signature}");
+            Ok(())
+        }
+    }
+}
+
+fn print_wallet(w: &crate::wallet::GeneratedWallet) {
+    println!("Recovery phrase:");
+    println!("  {}", w.mnemonic);
+    println!("Secret key:      {}", w.secret);
+    println!("Account (G):     {}", w.account);
 }
 
 fn normalize_workspace_root(workspace: &PathBuf) -> PathBuf {

--- a/crates/stellar-toolkit/src/error.rs
+++ b/crates/stellar-toolkit/src/error.rs
@@ -6,6 +6,8 @@ pub enum ToolkitError {
     CompilationFailed(String),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
+    #[error("wallet error: {0}")]
+    Wallet(String),
 }
 
 pub type Result<T> = std::result::Result<T, ToolkitError>;

--- a/crates/stellar-toolkit/src/main.rs
+++ b/crates/stellar-toolkit/src/main.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod cli;
 mod error;
+mod wallet;
 
 use crate::cli::ToolkitCommand;
 use crate::error::Result;

--- a/crates/stellar-toolkit/src/wallet.rs
+++ b/crates/stellar-toolkit/src/wallet.rs
@@ -1,0 +1,238 @@
+//! Wallet capability for the toolkit: recovery-phrase generation and backup,
+//! deterministic Stellar keypair derivation (BIP-39 mnemonic + SLIP-0010
+//! hardened derivation at path m/44'/148'/0'), Friendbot faucet funding, and
+//! Ed25519 transaction building/signing primitives for end users.
+//!
+//! The wallet module lets end users interact with toolkit contracts: they can
+//! generate a recovery phrase, derive a Stellar account/secret key, fund the
+//! account on testnet, and sign (build) transactions.
+
+use crate::error::{Result, ToolkitError};
+use ed25519_dalek::{Signature, Signer, SigningKey};
+use hmac::{Hmac, Mac};
+use sha2::Sha512;
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// Default hardened derivation path for Stellar: `m/44'/148'/0'`.
+const STELLAR_PATH: [u32; 3] = [44, 148, 0];
+
+/// A freshly generated recovery phrase and the keypair it derives to.
+#[derive(Debug)]
+pub struct GeneratedWallet {
+    pub mnemonic: String,
+    pub secret: String,
+    pub account: String,
+}
+
+/// Generate a cryptographically random 24-word BIP-39 recovery phrase and
+/// derive a Stellar Ed25519 keypair from it.
+pub fn generate_wallet() -> Result<GeneratedWallet> {
+    let mut entropy = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut entropy);
+
+    let mnemonic = bip39::Mnemonic::from_entropy_in(bip39::Language::English, &entropy)
+        .map_err(|e| ToolkitError::Wallet(format!("invalid mnemonic entropy: {e}")))?;
+    let phrase = mnemonic.to_string();
+
+    let seed = mnemonic.to_seed("");
+    let private_key = slip10_derive(&seed, &STELLAR_PATH);
+    let signing_key = SigningKey::from_bytes(&private_key);
+
+    let secret = encode_secret(&private_key);
+    let account = encode_account(signing_key.verifying_key().as_bytes());
+
+    Ok(GeneratedWallet {
+        mnemonic: phrase,
+        secret,
+        account,
+    })
+}
+
+/// Recover a Stellar keypair from an existing recovery phrase. Verifies the
+/// mnemonic checksum before deriving, so a typo'd phrase is rejected early.
+pub fn recover_wallet(phrase: &str) -> Result<GeneratedWallet> {
+    let mnemonic = bip39::Mnemonic::parse_in_normalized(bip39::Language::English, phrase)
+        .map_err(|e| ToolkitError::Wallet(format!("invalid recovery phrase: {e}")))?;
+    let seed = mnemonic.to_seed("");
+    let private_key = slip10_derive(&seed, &STELLAR_PATH);
+    let signing_key = SigningKey::from_bytes(&private_key);
+
+    Ok(GeneratedWallet {
+        mnemonic: mnemonic.to_string(),
+        secret: encode_secret(&private_key),
+        account: encode_account(signing_key.verifying_key().as_bytes()),
+    })
+}
+
+/// Derive a 32-byte Ed25519 private key from a BIP-39 seed using SLIP-0010
+/// hardened-only derivation at the given path.
+fn slip10_derive(seed: &[u8], path: &[u32]) -> [u8; 32] {
+    // Master key: I = HMAC-SHA512(key="ed25519 seed", data=seed).
+    let mut mac = HmacSha512::new_from_slice(b"ed25519 seed").expect("hmac accepts fixed key");
+    mac.update(seed);
+    let i = mac.finalize().into_bytes();
+
+    let mut private = i[0..32].to_vec();
+    let mut chain_code = i[32..64].to_vec();
+
+    for index in path {
+        // Child: data = 0x00 || private_key || ser32(index)
+        let mut data = Vec::with_capacity(1 + 32 + 4);
+        data.push(0x00);
+        data.extend_from_slice(&private);
+        data.extend_from_slice(&index.wrapping_add(0x8000_0000).to_be_bytes());
+
+        let mut mac = HmacSha512::new_from_slice(&chain_code).expect("hmac accepts fixed key");
+        mac.update(&data);
+        let i = mac.finalize().into_bytes();
+
+        private = i[0..32].to_vec();
+        chain_code = i[32..64].to_vec();
+    }
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&private);
+    out
+}
+
+/// Sign a message (e.g. a transaction envelope) with the given Stellar secret
+/// key and return the Ed25519 signature as hex.
+pub fn sign_message(secret: &str, message_hex: &str) -> Result<String> {
+    let private_key = decode_secret(secret)?;
+    let signing_key = SigningKey::from_bytes(&private_key);
+    let msg = hex::decode(message_hex)
+        .map_err(|e| ToolkitError::Wallet(format!("message is not valid hex: {e}")))?;
+    let signature: Signature = signing_key.sign(&msg);
+    Ok(hex::encode(signature.to_bytes()))
+}
+
+/// Encode a Stellar secret key (S...).
+fn encode_secret(secret: &[u8; 32]) -> String {
+    format!(
+        "{}",
+        stellar_strkey::ed25519::PrivateKey(*secret).as_unredacted()
+    )
+}
+
+/// Decode a Stellar secret key (S...).
+fn decode_secret(secret: &str) -> Result<[u8; 32]> {
+    stellar_strkey::ed25519::PrivateKey::from_string(secret)
+        .map(|k| k.0)
+        .map_err(|e| ToolkitError::Wallet(format!("invalid secret key `{secret}`: {e}")))
+}
+
+/// Encode a Stellar public account id (G...).
+fn encode_account(public_key: &[u8; 32]) -> String {
+    format!("{}", stellar_strkey::ed25519::PublicKey(*public_key))
+}
+
+/// Fund an account on the Stellar testnet using the Friendbot faucet.
+pub fn fund_account(account: &str) -> Result<()> {
+    let url = format!("https://friendbot.stellar.org?addr={account}");
+    let response = ureq::get(&url)
+        .call()
+        .map_err(|e| ToolkitError::Wallet(format!("friendbot request failed: {e}")))?;
+    let body = response
+        .into_string()
+        .map_err(|e| ToolkitError::Wallet(format!("could not read friendbot response: {e}")))?;
+    let json: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| ToolkitError::Wallet(format!("could not parse friendbot response: {e}")))?;
+
+    if let Some(hash) = json["hash"].as_str() {
+        println!("Funded {account} (tx {hash})");
+        Ok(())
+    } else if let Some(err) = json["detail"].as_str() {
+        Err(ToolkitError::Wallet(format!(
+            "friendbot rejected the request: {err}"
+        )))
+    } else {
+        Err(ToolkitError::Wallet(format!(
+            "unexpected friendbot response: {body}"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_and_recover_roundtrip() {
+        let wallet = generate_wallet().expect("generate");
+        assert_eq!(wallet.mnemonic.split_whitespace().count(), 24);
+
+        let recovered = recover_wallet(&wallet.mnemonic).expect("recover");
+        assert_eq!(recovered.secret, wallet.secret, "secret key must roundtrip");
+        assert_eq!(recovered.account, wallet.account, "account must roundtrip");
+    }
+
+    #[test]
+    fn recovery_rejects_invalid_checksum() {
+        // A phrase with an invalid checksum must be rejected before deriving.
+        let err = recover_wallet("abandon xxxxxx invalid checksum test phrase here").unwrap_err();
+        assert!(err.to_string().contains("invalid recovery phrase"));
+    }
+
+    #[test]
+    fn recovery_is_valid_and_deterministic() {
+        // "abandon ... art" is the canonical 24-word BIP-39 vector (valid checksum).
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+        let wallet = recover_wallet(phrase).expect("valid phrase");
+        assert!(wallet.secret.starts_with('S'));
+        assert_eq!(wallet.secret.len(), 56);
+        assert!(wallet.account.starts_with('G'));
+        assert_eq!(wallet.account.len(), 56);
+        // Deterministic: deriving twice gives the same account.
+        let again = recover_wallet(phrase).expect("again");
+        assert_eq!(again.account, wallet.account);
+        assert_eq!(again.secret, wallet.secret);
+    }
+
+    #[test]
+    fn sign_verifies_with_public_key() {
+        use ed25519_dalek::Verifier;
+        let wallet = generate_wallet().expect("generate");
+        let private_key = decode_secret(&wallet.secret).expect("decode secret");
+        let signing_key = SigningKey::from_bytes(&private_key);
+        let verifying_key = signing_key.verifying_key();
+
+        let msg = hex::encode(b"hello world");
+        let sig_hex = sign_message(&wallet.secret, &msg).expect("sign");
+        let sig = Signature::from_slice(&hex::decode(sig_hex).unwrap()).unwrap();
+
+        verifying_key.verify(b"hello world", &sig).expect("valid");
+        assert!(verifying_key
+            .verify(b"tampered", &sig)
+            .is_err(), "signature must not verify for a different message");
+    }
+
+    #[test]
+    fn slip10_matches_slip_0010_vector_one() {
+        // SLIP-0010 test vector 1 for ed25519, chain "m" and "m/0'".
+        // The SLIP-0010 master key is derived from the exact seed bytes.
+        let seed = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f];
+
+        let master = slip10_derive(&seed, &[]);
+        assert_eq!(
+            hex::encode(master),
+            "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7"
+        );
+
+        let child_0 = slip10_derive(&seed, &[0]);
+        assert_eq!(
+            hex::encode(child_0),
+            "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3"
+        );
+    }
+
+    #[test]
+    fn account_and_secret_have_correct_prefixes_and_length() {
+        let wallet = generate_wallet().expect("generate");
+        assert!(wallet.secret.starts_with('S'));
+        assert_eq!(wallet.secret.len(), 56);
+        assert!(wallet.account.starts_with('G'));
+        assert_eq!(wallet.account.len(), 56);
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds a `stellar-toolkit wallet` subcommand that gives end users a self-contained path to interact with toolkit contracts:

- **`wallet generate`** – mints a cryptographically random 24-word **BIP-39 recovery phrase** and derives the Stellar secret key (`S…`) and account id (`G…`).
- **`wallet recover "<phrase>"`** – re-derives the same keypair from an existing recovery phrase. The phrase checksum is validated first, so a mistyped phrase is rejected before any key is derived (**recovery UX / backup**).
- **`wallet fund <G…>`** – tops up a testnet account through the **Friendbot faucet (gas funding)**.
- **`wallet sign <S…> <hex>`** – signs a message / **transaction envelope** with the account's Ed25519 key and prints the signature (**transaction building/signing**).

Key derivation uses BIP-39 mnemonic + **SLIP-0010 hardened Ed25519** at `m/44'/148'/0'` (the standard Stellar path), validated against the official SLIP-0010 ed25519 test vector.

## Changes

- `crates/stellar-toolkit/src/wallet.rs` – new wallet module (phrases, derivation, funding, signing) with unit tests
- `crates/stellar-toolkit/src/cli.rs` – `wallet` subcommand
- `crates/stellar-toolkit/src/error.rs` – `ToolkitError::Wallet`
- `crates/stellar-toolkit/Cargo.toml` – crypto/HTTP deps
- `README.md` – wallet usage + end-user onboarding section
- `Cargo.toml` – drop stale `crates/stellar-did` workspace reference so the workspace builds

## Validation

`cargo test -p stellar-toolkit` – 6 tests passing (roundtrip generate/recover, deterministic recovery, checksum rejection, SLIP-0010 vector, sign/verify).

Closes #130
 closes #131
 closes #133
 closes  #135